### PR TITLE
[visual] Remove inheritance from events

### DIFF
--- a/visual/events/allocated_array_event.hpp
+++ b/visual/events/allocated_array_event.hpp
@@ -1,21 +1,19 @@
 #ifndef VISUAL_ALLOCATED_ARRAY_EVENT_HPP
 #define VISUAL_ALLOCATED_ARRAY_EVENT_HPP
 
-#include "event.hpp"
-
+#include <cstddef>
 #include <cstdint>
 
 namespace visual
 {
-class Allocated_Array_Event : public Event
+
+class Allocated_Array_Event
 {
  public:
 	Allocated_Array_Event(
 	    std::uint64_t address,
 	    std::size_t   element_size,
 	    std::size_t   size);
-
-	~Allocated_Array_Event() override = default;
 
 	[[nodiscard]] std::uint64_t address() const;
 	[[nodiscard]] std::size_t   element_size() const;

--- a/visual/events/copy_assignment_event.hpp
+++ b/visual/events/copy_assignment_event.hpp
@@ -1,7 +1,6 @@
 #ifndef VISUAL_COPY_ASSIGNMENT_EVENT_HPP
 #define VISUAL_COPY_ASSIGNMENT_EVENT_HPP
 
-#include "event.hpp"
 #include "memory_value.hpp"
 
 #include <cstdint>
@@ -9,12 +8,10 @@
 namespace visual
 {
 
-class Copy_Assignment_Event : public Event
+class Copy_Assignment_Event
 {
  public:
 	Copy_Assignment_Event(std::uint64_t address, Memory_Value value);
-
-	~Copy_Assignment_Event() override = default;
 
 	[[nodiscard]] std::uint64_t       address() const;
 	[[nodiscard]] const Memory_Value &value() const;

--- a/visual/events/deallocated_array_event.hpp
+++ b/visual/events/deallocated_array_event.hpp
@@ -1,18 +1,15 @@
 #ifndef VISUAL_DEALLOCATED_ARRAY_EVENT_HPP
 #define VISUAL_DEALLOCATED_ARRAY_EVENT_HPP
 
-#include "event.hpp"
 
 #include <cstdint>
 
 namespace visual
 {
-class Deallocated_Array_Event : public Event
+class Deallocated_Array_Event
 {
  public:
-	Deallocated_Array_Event(std::uint64_t address);
-
-	~Deallocated_Array_Event() override = default;
+	explicit Deallocated_Array_Event(std::uint64_t address);
 
 	[[nodiscard]] std::uint64_t address() const;
 

--- a/visual/events/event.cpp
+++ b/visual/events/event.cpp
@@ -1,17 +1,14 @@
+
 #include "event.hpp"
 
 #include "main_window.hpp"
 
 namespace visual
 {
-void Event::Dispatch(std::unique_ptr<Event> event)
+
+void Dispatch(Event &&event)
 {
 	Main_Window::instance().add_event(std::move(event));
-}
-
-const char *Event::name() const
-{
-	return typeid(*this).name();
 }
 
 } // namespace visual

--- a/visual/events/event.hpp
+++ b/visual/events/event.hpp
@@ -1,21 +1,23 @@
 #ifndef VISUAL_EVENT_HPP
 #define VISUAL_EVENT_HPP
 
-#include <cstdint>
-#include <memory>
+#include "allocated_array_event.hpp"
+#include "copy_assignment_event.hpp"
+#include "deallocated_array_event.hpp"
+#include "allocated_array_event.hpp"
+#include "move_assignment_event.hpp"
+
+#include <typeinfo>
+#include <variant>
 
 namespace visual
 {
-class Event
-{
- public:
-	static void Dispatch(std::unique_ptr<Event> event);
 
-	virtual ~Event() = default;
+using Event =
+    std::variant<Allocated_Array_Event, Deallocated_Array_Event, Move_Assignment_Event, Copy_Assignment_Event>;
 
-	[[nodiscard]] const char *name() const;
-};
+void Dispatch(Event&& event);
 
-} // namespace visual
+}
 
 #endif

--- a/visual/events/move_assignment_event.hpp
+++ b/visual/events/move_assignment_event.hpp
@@ -1,22 +1,19 @@
 #ifndef VISUAL_MOVE_ASSIGNMENT_EVENT_HPP
 #define VISUAL_MOVE_ASSIGNMENT_EVENT_HPP
 
-#include "event.hpp"
 #include "memory_value.hpp"
 
 #include <cstdint>
 
 namespace visual
 {
-class Move_Assignment_Event : public Event
+class Move_Assignment_Event
 {
  public:
 	Move_Assignment_Event(
 	    std::uint64_t to_address,
 	    std::uint64_t from_address,
 	    Memory_Value  value);
-
-	~Move_Assignment_Event() override = default;
 
 	[[nodiscard]] std::uint64_t       to_address() const;
 	[[nodiscard]] std::uint64_t       from_address() const;

--- a/visual/main_window.cpp
+++ b/visual/main_window.cpp
@@ -48,7 +48,7 @@ const fs::path &Main_Window::executable_path()
 	return m_executable;
 }
 
-void Main_Window::add_event(std::unique_ptr<Event> &&event)
+void Main_Window::add_event(Event &&event)
 {
 	m_viewport.add_event(std::move(event));
 }

--- a/visual/main_window.hpp
+++ b/visual/main_window.hpp
@@ -26,7 +26,7 @@ class Main_Window
 
 	const std::filesystem::path &executable_path();
 
-	void add_event(std::unique_ptr<Event> &&event);
+	void add_event(Event &&event);
 
 	void initialise(const std::vector<std::string> &arguments);
 	void start();

--- a/visual/monitors/element_monitor.hpp
+++ b/visual/monitors/element_monitor.hpp
@@ -55,11 +55,9 @@ class Element_Monitor
 		Element_Monitor temp{ element };
 		swap(*this, temp);
 
-		auto address = reinterpret_cast<std::uint64_t>(this);
-
-		visual::Event::Dispatch(std::make_unique<Copy_Assignment_Event>(
-		    address,
-		    Memory_Value{ m_initialised, to_string() }));
+		visual::Dispatch(Copy_Assignment_Event{
+		    reinterpret_cast<std::uint64_t>(this),
+		    Memory_Value{ m_initialised, to_string() } });
 
 		return *this;
 	}
@@ -72,13 +70,10 @@ class Element_Monitor
 		swap(*this, tmp);
 		swap(*this, element);
 
-		auto to_address   = reinterpret_cast<std::uint64_t>(this);
-		auto from_address = reinterpret_cast<std::uint64_t>(&element);
-
-		visual::Event::Dispatch(std::make_unique<Move_Assignment_Event>(
-		    to_address,
-		    from_address,
-		    Memory_Value{ m_initialised, to_string() }));
+		visual::Dispatch(Move_Assignment_Event{
+		    reinterpret_cast<std::uint64_t>(this),
+		    reinterpret_cast<std::uint64_t>(&element),
+		    Memory_Value{ m_initialised, to_string() } });
 
 		return *this;
 	}

--- a/visual/monitors/memory_monitor.hpp
+++ b/visual/monitors/memory_monitor.hpp
@@ -3,6 +3,7 @@
 
 #include "allocated_array_event.hpp"
 #include "deallocated_array_event.hpp"
+#include "event.hpp"
 
 #include <cstdint>
 
@@ -16,10 +17,10 @@ class Memory_Monitor
 	{
 		void *pointer = ::operator new(size * sizeof(T));
 
-		visual::Event::Dispatch(std::make_unique<Allocated_Array_Event>(
+		visual::Dispatch(Allocated_Array_Event{
 		    reinterpret_cast<std::uint64_t>(pointer),
 		    sizeof(T),
-		    size));
+		    size });
 
 		T *typed_pointer = reinterpret_cast<T *>(pointer);
 		for (std::size_t i = 0; i < size; ++i)
@@ -33,8 +34,8 @@ class Memory_Monitor
 
 	void deallocate(T *pointer) const
 	{
-		visual::Event::Dispatch(std::make_unique<Deallocated_Array_Event>(
-		    reinterpret_cast<std::uint64_t>(pointer)));
+		visual::Dispatch(Deallocated_Array_Event{
+		    reinterpret_cast<std::uint64_t>(pointer) });
 
 		::operator delete(pointer);
 	}

--- a/visual/viewport.hpp
+++ b/visual/viewport.hpp
@@ -5,6 +5,7 @@
 #include "buffer.hpp"
 #include "copy_assignment_event.hpp"
 #include "deallocated_array_event.hpp"
+#include "event.hpp"
 #include "move_assignment_event.hpp"
 
 #include <SFML/Graphics/Drawable.hpp>
@@ -18,15 +19,15 @@ namespace visual
 class Viewport
 {
  public:
-	void add_event(std::unique_ptr<Event> &&event);
+	void add_event(Event &&event);
 	void update(std::chrono::microseconds deltaTime);
 
 	void draw() const;
 
  private:
-	std::list<std::unique_ptr<Event>> m_events;
-	std::vector<Buffer>               m_buffers;
-	std::chrono::microseconds         m_eventTimeout{ -1 };
+	std::list<Event>          m_events;
+	std::vector<Buffer>       m_buffers;
+	std::chrono::microseconds m_eventTimeout{ -1 };
 
 	[[nodiscard]] bool process(const Event &event);
 	[[nodiscard]] bool process(const Allocated_Array_Event &event);


### PR DESCRIPTION
Since their type needs to be known in order to process them variant is a
better choice over dynamic cast.