### PR TITLE
[visual] Improve event log message

### DIFF
--- a/visual/events/allocated_array_event.cpp
+++ b/visual/events/allocated_array_event.cpp
@@ -1,5 +1,7 @@
 #include "allocated_array_event.hpp"
 
+#include <fmt/format.h>
+
 namespace visual
 {
 Allocated_Array_Event::Allocated_Array_Event(
@@ -25,6 +27,15 @@ std::size_t Allocated_Array_Event::element_size() const
 std::size_t Allocated_Array_Event::size() const
 {
 	return m_size;
+}
+
+std::string Allocated_Array_Event::to_string() const
+{
+	return fmt::format(
+	    "Allocated {0} elements of size {1} at {2:#x}",
+	    m_size,
+	    m_element_size,
+	    m_address);
 }
 
 } // namespace visual

--- a/visual/events/allocated_array_event.hpp
+++ b/visual/events/allocated_array_event.hpp
@@ -5,6 +5,7 @@
 
 #include <cstddef>
 #include <cstdint>
+#include <string>
 
 namespace visual
 {
@@ -20,6 +21,8 @@ class Allocated_Array_Event
 	[[nodiscard]] Address     address() const;
 	[[nodiscard]] std::size_t element_size() const;
 	[[nodiscard]] std::size_t size() const;
+
+	[[nodiscard]] std::string to_string() const;
 
  private:
 	Address     m_address;

--- a/visual/events/copy_assignment_event.cpp
+++ b/visual/events/copy_assignment_event.cpp
@@ -1,5 +1,7 @@
 #include "copy_assignment_event.hpp"
 
+#include <fmt/format.h>
+
 namespace visual
 {
 
@@ -17,6 +19,11 @@ Address Copy_Assignment_Event::address() const
 const Memory_Value &Copy_Assignment_Event::value() const
 {
 	return m_value;
+}
+
+std::string Copy_Assignment_Event::to_string() const
+{
+	return fmt::format("Copy {0} to {1:#x}", m_value.value(), m_address);
 }
 
 } // namespace visual

--- a/visual/events/copy_assignment_event.hpp
+++ b/visual/events/copy_assignment_event.hpp
@@ -5,6 +5,7 @@
 #include "memory_value.hpp"
 
 #include <cstdint>
+#include <string>
 
 namespace visual
 {
@@ -16,6 +17,8 @@ class Copy_Assignment_Event
 
 	[[nodiscard]] Address             address() const;
 	[[nodiscard]] const Memory_Value &value() const;
+
+	[[nodiscard]] std::string to_string() const;
 
  private:
 	Address      m_address;

--- a/visual/events/deallocated_array_event.cpp
+++ b/visual/events/deallocated_array_event.cpp
@@ -1,7 +1,10 @@
 #include "deallocated_array_event.hpp"
 
+#include <fmt/format.h>
+
 namespace visual
 {
+
 Deallocated_Array_Event::Deallocated_Array_Event(Address address)
     : m_address(address)
 {
@@ -11,4 +14,10 @@ Address Deallocated_Array_Event::address() const
 {
 	return m_address;
 }
+
+std::string Deallocated_Array_Event::to_string() const
+{
+	return fmt::format("Deallocate {0:#x}", m_address);
+}
+
 } // namespace visual

--- a/visual/events/deallocated_array_event.hpp
+++ b/visual/events/deallocated_array_event.hpp
@@ -4,6 +4,7 @@
 #include "address.hpp"
 
 #include <cstdint>
+#include <string>
 
 namespace visual
 {
@@ -13,6 +14,8 @@ class Deallocated_Array_Event
 	explicit Deallocated_Array_Event(Address address);
 
 	[[nodiscard]] Address address() const;
+
+	[[nodiscard]] std::string to_string() const;
 
  private:
 	Address m_address;

--- a/visual/events/event.cpp
+++ b/visual/events/event.cpp
@@ -11,4 +11,11 @@ void Dispatch(Event &&event)
 	Main_Window::instance().add_event(std::move(event));
 }
 
+std::string to_string(const Event &event)
+{
+	return std::visit(
+	    [](auto &&event_typed) { return event_typed.to_string(); },
+	    event);
+}
+
 } // namespace visual

--- a/visual/events/event.hpp
+++ b/visual/events/event.hpp
@@ -18,6 +18,8 @@ using Event =
 
 void Dispatch(Event&& event);
 
+std::string to_string(const Event& event);
+
 }
 
 #endif

--- a/visual/events/move_assignment_event.cpp
+++ b/visual/events/move_assignment_event.cpp
@@ -1,12 +1,14 @@
 #include "move_assignment_event.hpp"
 
+#include <fmt/format.h>
+
 namespace visual
 {
 
 Move_Assignment_Event::Move_Assignment_Event(
-    Address to_address,
-    Address from_address,
-    Memory_Value  value)
+    Address      to_address,
+    Address      from_address,
+    Memory_Value value)
     : m_to_address(to_address)
     , m_from_address(from_address)
     , m_value(std::move(value))
@@ -26,6 +28,15 @@ Address Move_Assignment_Event::from_address() const
 const Memory_Value &Move_Assignment_Event::value() const
 {
 	return m_value;
+}
+
+std::string Move_Assignment_Event::to_string() const
+{
+	return fmt::format(
+	    "Moved {0} from {1:#x} to {2:#x}",
+	    m_value.value(),
+	    m_from_address,
+	    m_to_address);
 }
 
 } // namespace visual

--- a/visual/events/move_assignment_event.hpp
+++ b/visual/events/move_assignment_event.hpp
@@ -5,6 +5,7 @@
 #include "memory_value.hpp"
 
 #include <cstdint>
+#include <string>
 
 namespace visual
 {
@@ -19,6 +20,8 @@ class Move_Assignment_Event
 	[[nodiscard]] Address             to_address() const;
 	[[nodiscard]] Address             from_address() const;
 	[[nodiscard]] const Memory_Value &value() const;
+
+	[[nodiscard]] std::string to_string() const;
 
  private:
 	Address      m_to_address;

--- a/visual/viewport.cpp
+++ b/visual/viewport.cpp
@@ -60,7 +60,7 @@ namespace visual
 
 void Viewport::add_event(Event &&event)
 {
-	spdlog::trace("Added eventof type: {}", typeid(event).name());
+	spdlog::trace("Added eventof type: {}", to_string(event));
 	m_events.push_back(std::move(event));
 }
 
@@ -95,7 +95,7 @@ void Viewport::draw() const
 
 bool Viewport::process(const Event &event)
 {
-	spdlog::trace("Processing event of type: {}", typeid(event).name());
+	spdlog::trace("Processing event of type: {}", to_string(event));
 
 	return std::visit(
 	    [this](auto &&event_typed) { return process(event_typed); },


### PR DESCRIPTION
Use a proper message when logging events, this allows the developer to
better see what happened in passed events not just the events
themselves.