### PR TITLE
[visual] Bug: Element monitor initialised was not set

### DIFF
--- a/visual/monitors/element_monitor.hpp
+++ b/visual/monitors/element_monitor.hpp
@@ -110,6 +110,11 @@ class Element_Monitor
 		return m_value != element.m_value;
 	}
 
+	void uninitialise()
+	{
+		m_initialised = false;
+	}
+
  private:
 	bool  m_initialised = false;
 	Value m_value{};

--- a/visual/monitors/memory_monitor.hpp
+++ b/visual/monitors/memory_monitor.hpp
@@ -5,6 +5,9 @@
 #include "allocated_array_event.hpp"
 #include "deallocated_array_event.hpp"
 #include "event.hpp"
+#include "templates.hpp"
+
+DEFINE_HAS_MEMBER(uninitialise);
 
 namespace visual
 {
@@ -23,6 +26,10 @@ class Memory_Monitor
 		for (std::size_t i = 0; i < size; ++i)
 		{
 			new (typed_pointer + i) T{};
+			if constexpr (has_member_uninitialise_v<T>)
+			{
+				typed_pointer[i].uninitialise();
+			}
 		}
 
 		return typed_pointer;


### PR DESCRIPTION
We need to set this value when allocating memory, otherwise it will be
true. We cannot know if it was initialised from the constructors because
by definition calling a consturctor is initialisation.