### PR TITLE
[dsa] remove Dynamic_Array allocator constructor member call

### DIFF
--- a/dsa/include/dsa/dynamic_array.hpp
+++ b/dsa/include/dsa/dynamic_array.hpp
@@ -238,7 +238,7 @@ class Dynamic_Array
 	// Allocator::deallocate cannot be called with nullptr, thus creating an
 	// allocation of 0 elements allows us to call deallocate without
 	// explicitly checking for nullptr when resizing
-	Pointer m_array = m_allocator.allocate(0);
+	Pointer m_array = Alloc_Traits::allocate(m_allocator, 0);
 };
 
 } // namespace dsa


### PR DESCRIPTION
Constructor calls should be done through the Alloc_Traits interface to
account for allocators which do not provide a custom implementation.