### PR TITLE
[visual] Set element monitor value as uninitialised on construction

### DIFF
--- a/visual/monitors/element_monitor.hpp
+++ b/visual/monitors/element_monitor.hpp
@@ -6,6 +6,7 @@
 #include "event.hpp"
 #include "move_assignment_event.hpp"
 #include "swap_event.hpp"
+#include "uninitialised_tag.hpp"
 
 #include <fmt/format.h>
 #include <fmt/ostream.h>
@@ -17,6 +18,10 @@ template<typename Value>
 class Element_Monitor
 {
  public:
+	Element_Monitor(uninitialised_tag) : m_initialised(false)
+	{
+	}
+
 	Element_Monitor() : Element_Monitor{0}
 	{
 	}
@@ -119,11 +124,6 @@ class Element_Monitor
 	bool operator!=(const Element_Monitor<Value> element) const
 	{
 		return m_value != element.m_value;
-	}
-
-	void uninitialise()
-	{
-		m_initialised = false;
 	}
 
  private:

--- a/visual/monitors/uninitialised_tag.hpp
+++ b/visual/monitors/uninitialised_tag.hpp
@@ -1,0 +1,6 @@
+#ifndef VISUAL_UNINITIALISED_TAG_HPP
+#define VISUAL_UNINITIALISED_TAG_HPP
+
+class uninitialised_tag {};
+
+#endif


### PR DESCRIPTION
Since the Element_Monitor was being initialised with a valid value and
then reset to uninitialised the UI showed the element as being
initialised. This happens because the constructor sends and event and
the uninitialise was not sending one.