### PR TITLE
[visual] Add missing include statement

### DIFF
--- a/visual/memory_representation/memory.cpp
+++ b/visual/memory_representation/memory.cpp
@@ -1,5 +1,6 @@
 #include "memory.hpp"
 
+#include <algorithm>
 #include <stdexcept>
 
 namespace visual


### PR DESCRIPTION
clang was refusing to compile this file due to a missing include after an upgrade.