### PR TITLE
[dsa] Introduce Monitor class

### DIFF
--- a/dsa/include/dsa/memory_monitor.hpp
+++ b/dsa/include/dsa/memory_monitor.hpp
@@ -1,0 +1,163 @@
+#ifndef DSA_MEMORY_MONITOR_HPP
+#define DSA_MEMORY_MONITOR_HPP
+
+#include <dsa/allocator_traits.hpp>
+#include <dsa/default_allocator.hpp>
+
+#include <cassert>
+#include <cstddef>
+#include <memory>
+
+namespace dsa
+{
+
+template<typename Handler, typename Type>
+concept Memory_Monitor_Event_Handler =
+    requires(Handler handler, Type *destination, Type const *source, size_t count)
+{
+	{handler.on_allocate(destination, count)};
+
+	{handler.on_construct(destination)};
+
+	{handler.on_copy_construct(destination, source)};
+	{handler.on_copy_assign(destination, source)};
+	{handler.on_underlying_value_copy_assign(destination)};
+
+	{handler.on_move_construct(destination, source)};
+	{handler.on_move_assign(destination, source)};
+	{handler.on_underlying_value_move_assign(destination)};
+
+	{handler.on_destroy(destination)};
+
+	{handler.before_deallocate(destination, count)} -> std::same_as<bool>;
+	{handler.on_deallocate(destination, count)};
+};
+
+/// @brief Monitors the allocations and object lifetime within those allocations
+///
+/// @description Tracks certain actions and calls the callback provided in
+/// Memory_Monitor_Event_Handler. This allows external code to peek at the state
+/// of elements within a container. A consequence of the implementation is that
+/// the lifetime of stack variables is tracked aswell. The event handler must
+/// figure out which events they are interested in by keeping the necessary
+/// state.
+template<typename Value_t, Memory_Monitor_Event_Handler<Value_t> Handler>
+class Memory_Monitor
+{
+ public:
+	/// @brief Wraps around a value in order to monitor its lifetime
+	class Element_Monitor
+	{
+	 public:
+		template<typename... Arguments>
+		explicit Element_Monitor(Arguments &&...arguments)
+		    : m_value(std::forward<Arguments>(arguments)...)
+		{
+			handler()->on_construct(this);
+		}
+
+		~Element_Monitor()
+		{
+			handler()->on_destroy(this);
+		}
+
+		Element_Monitor(Element_Monitor const &element)
+		    : m_value(element.m_value)
+		{
+			handler()->on_copy_construct(this, &element);
+		}
+
+		auto operator=(Element_Monitor const &element) -> Element_Monitor &
+		{
+			m_value = element.m_value;
+			handler()->on_copy_assign(this, &element);
+			return *this;
+		}
+
+		auto operator=(Value_t const &value) -> Element_Monitor &
+		{
+			m_value = value;
+			handler()->on_underlying_value_copy_assign(this);
+			return *this;
+		}
+
+		Element_Monitor(Element_Monitor &&element) noexcept
+		    : m_value(std::move(element.m_value))
+		{
+			handler()->on_move_construct(this, &element);
+		}
+
+		auto operator=(Element_Monitor &&element) noexcept
+		    -> Element_Monitor &
+		{
+			m_value = std::move(element.m_value);
+			handler()->on_move_assign(this, &element);
+			return *this;
+		}
+
+		auto operator=(Value_t &&value) noexcept -> Element_Monitor &
+		{
+			m_value = std::move(value);
+			handler()->on_underlying_value_move_assign(this);
+			return *this;
+		}
+
+		explicit operator Value_t &()
+		{
+			return m_value;
+		}
+
+		explicit operator Value_t const &() const
+		{
+			return m_value;
+		}
+
+	 private:
+		Value_t m_value{};
+	};
+
+	using Underlying_Value = Value_t;
+	using Value            = Element_Monitor;
+	using Pointer          = Value *;
+
+	explicit Memory_Monitor()
+	{
+		assert(
+	    handler() != nullptr
+	    && "Only one Monitor instance can be alive at any given time");
+	}
+
+	~Memory_Monitor() = default;
+
+	static auto handler() -> std::unique_ptr<Handler> &
+	{
+		static std::unique_ptr<Handler> handler;
+		return handler;
+	}
+
+	auto allocate(std::size_t count) -> Pointer
+	{
+		Allocator allocator;
+		Pointer   address = Alloc_Traits::allocate(allocator, count);
+		handler()->on_allocate(address, count);
+		return address;
+	}
+
+	void deallocate(Pointer address, std::size_t count)
+	{
+		Allocator allocator;
+		if (handler()->before_deallocate(address, count))
+		{
+			Alloc_Traits::deallocate(allocator, address, count);
+			handler()->on_deallocate(address, count);
+		}
+	}
+
+ private:
+	using Allocator    = Default_Allocator<Value>;
+	using Alloc_Traits = Allocator_Traits<Allocator>;
+};
+
+} // namespace dsa
+
+#endif

--- a/test/dsa/dsa_static/CMakeLists.txt
+++ b/test/dsa/dsa_static/CMakeLists.txt
@@ -1,8 +1,11 @@
 find_package(Catch2 REQUIRED)
 include(Catch)
 
-set(DSA_STATIC_TEST_INCLUDES "${CMAKE_CURRENT_LIST_DIR}")
-set(DSA_STATIC_TEST_FILES allocator_traits_tests.cpp)
+set(DSA_STATIC_TEST_INCLUDES
+	"${CMAKE_CURRENT_LIST_DIR}"
+	"${CMAKE_CURRENT_LIST_DIR}/utilities")
+
+set(DSA_STATIC_TEST_FILES allocator_traits_tests.cpp memory_monitor_tests.cpp)
 
 if(${DSA_STATIC_TESTS})
 	add_executable(dsa_static_tests ${DSA_STATIC_TEST_FILES})
@@ -21,6 +24,7 @@ endif()
 if(${DSA_STATIC_DEBUG_TESTS})
 	# Create an executable with conxtexpr tests executed at runtime in order to allow debugging
 	add_executable(dsa_runtime_tests ${DSA_STATIC_TEST_FILES})
+	target_include_directories(dsa_runtime_tests PRIVATE ${DSA_STATIC_TEST_INCLUDES})
 	target_link_libraries(dsa_runtime_tests PRIVATE dsa project_options project_warnings Catch2::Catch2WithMain)
 	target_compile_definitions(dsa_runtime_tests PRIVATE -DCATCH_CONFIG_RUNTIME_STATIC_REQUIRE)
 

--- a/test/dsa/dsa_static/memory_monitor_tests.cpp
+++ b/test/dsa/dsa_static/memory_monitor_tests.cpp
@@ -1,0 +1,605 @@
+#include "empty_value.hpp"
+#include "memory_monitor_scope.hpp"
+#include "no_default_constructor_value.hpp"
+
+#include <dsa/allocator_traits.hpp>
+#include <dsa/memory_monitor.hpp>
+
+#include <variant>
+
+#include <catch2/catch_all.hpp>
+
+namespace test
+{
+
+/// Data class used to store the parameters passed to an allocate or deallocate
+/// call.
+class Allocation_Event
+{
+ public:
+	enum class Type
+	{
+		Allocate,
+		Deallocate
+	};
+
+	Allocation_Event(Type type, void *pointer, size_t count)
+	    : m_type(type)
+	    , m_pointer(pointer)
+	    , m_count(count)
+	{
+	}
+
+	auto operator==(Allocation_Event const &event) const -> bool = default;
+	friend auto operator<<(std::ostream &stream, Allocation_Event const &event)
+	    -> std::ostream &;
+
+ private:
+	Type   m_type;
+	void  *m_pointer;
+	size_t m_count;
+};
+
+auto operator<<(std::ostream &stream, Allocation_Event::Type type)
+    -> std::ostream &
+{
+	switch (type)
+	{
+	case Allocation_Event::Type::Allocate:
+		stream << "Allocation";
+		break;
+
+	case Allocation_Event::Type::Deallocate:
+		stream << "Deallocation";
+		break;
+	};
+	return stream;
+}
+
+auto operator<<(std::ostream &stream, Allocation_Event const &event)
+    -> std::ostream &
+{
+	stream << event.m_type << " at address "
+	       << reinterpret_cast<uintptr_t>(event.m_pointer) << " with count "
+	       << event.m_count;
+	return stream;
+}
+
+/// Data class used to store the parameters passed to object lifetime
+/// manipulation functions. These involve construction, destruction and moves.
+class Object_Event
+{
+ public:
+	enum class Type
+	{
+		Construct,
+		Copy_Construct,
+		Copy_Assign,
+		Move_Construct,
+		Move_Assign,
+		Destroy
+	};
+
+	Object_Event(Type type, void *destination, void const *source = nullptr)
+	    : m_type(type)
+	    , m_destination(destination)
+	    , m_source(source)
+	{
+	}
+
+	auto operator==(Object_Event const &event) const -> bool = default;
+	friend auto operator<<(std::ostream &stream, Object_Event const &event)
+	    -> std::ostream &;
+
+ private:
+	Type        m_type;
+	void       *m_destination;
+	void const *m_source;
+};
+
+auto operator<<(std::ostream &stream, Object_Event::Type type) -> std::ostream &
+{
+	switch (type)
+	{
+	case Object_Event::Type::Construct:
+		stream << "Construction";
+		break;
+
+	case Object_Event::Type::Destroy:
+		stream << "Destruction";
+		break;
+
+	case Object_Event::Type::Copy_Construct:
+		stream << "Copy construction";
+		break;
+
+	case Object_Event::Type::Copy_Assign:
+		stream << "Copy assignment";
+		break;
+
+	case Object_Event::Type::Move_Construct:
+		stream << "Move construction";
+		break;
+
+	case Object_Event::Type::Move_Assign:
+		stream << "Move assignment";
+		break;
+	};
+	return stream;
+}
+
+auto operator<<(std::ostream &stream, Object_Event const &event) -> std::ostream &
+{
+	stream << event.m_type << " at address "
+	       << reinterpret_cast<uintptr_t>(event.m_destination);
+
+	if (event.m_source == nullptr)
+	{
+		return stream;
+	}
+
+	switch (event.m_type)
+	{
+	case Object_Event::Type::Construct:
+	case Object_Event::Type::Destroy:
+		break;
+
+	case Object_Event::Type::Copy_Construct:
+	case Object_Event::Type::Copy_Assign:
+	case Object_Event::Type::Move_Construct:
+	case Object_Event::Type::Move_Assign:
+		stream << " from address "
+		       << reinterpret_cast<uintptr_t>(event.m_source);
+		break;
+	};
+
+	return stream;
+}
+
+using Events = std::variant<Allocation_Event, Object_Event>;
+
+auto operator<<(std::ostream &stream, Events const &event) -> std::ostream &
+{
+	std::visit([&](auto const &type) { stream << type; }, event);
+	return stream;
+}
+
+template<typename T>
+auto create_allocate_event(T *pointer, size_t count) -> Events
+{
+	return Allocation_Event(
+	    Allocation_Event::Type::Allocate,
+	    static_cast<void *>(pointer),
+	    count);
+}
+
+template<typename T>
+auto create_deallocate_event(T *pointer, size_t count) -> Events
+{
+	return Allocation_Event(
+	    Allocation_Event::Type::Deallocate,
+	    static_cast<void *>(pointer),
+	    count);
+}
+
+template<typename T>
+auto create_construct_event(T *destination) -> Events
+{
+	return Object_Event(
+	    Object_Event::Type::Construct,
+	    static_cast<void *>(destination));
+}
+
+template<typename T>
+auto create_copy_construct_event(T *destination, T const *source) -> Events
+{
+	return Object_Event(
+	    Object_Event::Type::Copy_Construct,
+	    static_cast<void *>(destination),
+	    static_cast<void const *>(source));
+}
+
+template<typename T>
+auto create_copy_assign_event(T *destination, T const *source) -> Events
+{
+	return Object_Event(
+	    Object_Event::Type::Copy_Assign,
+	    static_cast<void *>(destination),
+	    static_cast<void const *>(source));
+}
+
+template<typename T>
+auto create_move_construct_event(T *destination, T const *source) -> Events
+{
+	return Object_Event(
+	    Object_Event::Type::Move_Construct,
+	    static_cast<void *>(destination),
+	    static_cast<void const *>(source));
+}
+
+template<typename T>
+auto create_move_assign_event(T *destination, T const *source) -> Events
+{
+	return Object_Event(
+	    Object_Event::Type::Move_Assign,
+	    static_cast<void *>(destination),
+	    static_cast<void const *>(source));
+}
+
+template<typename T>
+auto create_destroy_event(T *destination) -> Events
+{
+	return Object_Event(
+	    Object_Event::Type::Destroy,
+	    static_cast<void *>(destination));
+}
+
+/// Maintains a list events produced by the appropriate callback. The entries
+/// can be analysed to determine if the Memory_Monitor is calling the
+/// appropriate callbacks in the appropriate order
+class Event_Handler
+{
+ public:
+	template<typename T>
+	void on_allocate(T *address, size_t count)
+	{
+		m_events.emplace_back(create_allocate_event(address, count));
+	}
+
+	template<typename T>
+	void on_construct(T *address)
+	{
+		m_events.emplace_back(create_construct_event(address));
+	}
+
+	template<typename T>
+	void on_copy_construct(T *destination, T const *source)
+	{
+		m_events.emplace_back(
+		    create_copy_construct_event(destination, source));
+	}
+
+	template<typename T>
+	void on_copy_assign(T *destination, T const *source)
+	{
+		m_events.emplace_back(
+		    create_copy_assign_event(destination, source));
+	}
+
+	template<typename T>
+	void on_underlying_value_copy_assign(T *destination)
+	{
+		m_events.emplace_back(
+		    create_copy_assign_event<T>(destination, nullptr));
+	}
+
+	template<typename T>
+	void on_move_construct(T *destination, T const *source)
+	{
+		m_events.emplace_back(
+		    create_move_construct_event(destination, source));
+	}
+
+	template<typename T>
+	void on_move_assign(T *destination, T const *source)
+	{
+		m_events.emplace_back(
+		    create_move_assign_event(destination, source));
+	}
+
+	template<typename T>
+	void on_underlying_value_move_assign(T *destination)
+	{
+		m_events.emplace_back(
+		    create_move_assign_event<T>(destination, nullptr));
+	}
+
+	template<typename T>
+	void on_destroy(T *address)
+	{
+		m_events.emplace_back(create_destroy_event(address));
+	}
+
+	template<typename T>
+	auto before_deallocate(T * /* address */, size_t /* count */) -> bool
+	{
+		return m_allow_deallocate;
+	}
+
+	template<typename T>
+	void on_deallocate(T *address, size_t count)
+	{
+		m_events.emplace_back(create_deallocate_event(address, count));
+	}
+
+	void block_deallocate()
+	{
+		m_allow_deallocate = false;
+	}
+
+	void unblock_deallocate()
+	{
+		m_allow_deallocate = true;
+	}
+
+	[[nodiscard]] auto events() -> std::vector<Events> const &
+	{
+		return m_events;
+	}
+
+ private:
+	std::vector<Events> m_events;
+	bool                m_allow_deallocate = true;
+};
+
+TEST_CASE("No event is received if no actions were performed", "[monitor]")
+{
+	using Allocator = dsa::Memory_Monitor<Empty_Value, Event_Handler>;
+	Memory_Monitor_Scope<Allocator::Underlying_Value, Event_Handler> scope;
+
+	Allocator monitor;
+	REQUIRE(Allocator::handler()->events().empty());
+}
+
+TEST_CASE("Monitor notifies handler about allocations", "[monitor]")
+{
+	using Allocator    = dsa::Memory_Monitor<Empty_Value, Event_Handler>;
+	using Alloc_Traits = dsa::Allocator_Traits<Allocator>;
+
+	Memory_Monitor_Scope<Allocator::Underlying_Value, Event_Handler> scope;
+
+	Allocator    monitor;
+	const size_t count      = 5;
+	auto        *allocation = Alloc_Traits::allocate(monitor, count);
+
+	SECTION("Monitor detects calls to allocate")
+	{
+		REQUIRE(Allocator::handler()->events().size() == 1);
+		REQUIRE(
+		    Allocator::handler()->events().back()
+		    == create_allocate_event(allocation, count));
+
+		Alloc_Traits::deallocate(monitor, allocation, count);
+	}
+
+	SECTION("Monitor detects calls to deallocate")
+	{
+		Alloc_Traits::deallocate(monitor, allocation, count);
+
+		REQUIRE(
+		    Allocator::handler()->events().back()
+		    == create_deallocate_event(allocation, count));
+	}
+
+	SECTION("The handler can signal the Monitor to block a deallocate")
+	{
+		Allocator::handler()->block_deallocate();
+		Alloc_Traits::deallocate(monitor, allocation, count);
+
+		REQUIRE(Allocator::handler()->events().size() == 1);
+
+		Allocator::handler()->unblock_deallocate();
+		Alloc_Traits::deallocate(monitor, allocation, count);
+	}
+}
+
+TEST_CASE(
+    "Monitor detects construction and destruction of stack values",
+    "[monitor]")
+{
+	using Allocator = dsa::Memory_Monitor<Empty_Value, Event_Handler>;
+	Memory_Monitor_Scope<Allocator::Underlying_Value, Event_Handler> scope;
+
+	Allocator::Value *address = nullptr;
+	// Scope serves to call Value destructor
+	{
+		Allocator::Value value;
+		address = &value;
+	}
+
+	REQUIRE(
+	    Allocator::handler()->events().front()
+	    == create_construct_event(address));
+
+	REQUIRE(
+	    Allocator::handler()->events().back()
+	    == create_destroy_event(address));
+}
+
+TEST_CASE("Monitor notifies handler about object construction", "[monitor]")
+{
+	using Allocator    = dsa::Memory_Monitor<Empty_Value, Event_Handler>;
+	using Alloc_Traits = dsa::Allocator_Traits<Allocator>;
+
+	Memory_Monitor_Scope<Allocator::Underlying_Value, Event_Handler> scope;
+	Allocator monitor;
+
+	size_t count      = 1;
+	auto  *allocation = Alloc_Traits::allocate(monitor, count);
+
+	SECTION("Monitor detects construction through allocation traits")
+	{
+		Alloc_Traits::construct(
+		    monitor,
+		    allocation,
+		    Allocator::Underlying_Value{});
+
+		REQUIRE(
+		    Allocator::handler()->events().back()
+		    == create_construct_event(allocation));
+	}
+
+	SECTION("Monitor detects an uninitialised construct")
+	{
+		std::uninitialized_default_construct_n(allocation, 1);
+
+		REQUIRE(
+		    Allocator::handler()->events().back()
+		    == create_construct_event(allocation));
+	}
+
+	SECTION("Monitor detects copy construction")
+	{
+		Allocator::Value value;
+		std::uninitialized_fill_n(allocation, 1, value);
+
+		REQUIRE(
+		    Allocator::handler()->events().back()
+		    == create_copy_construct_event(allocation, &value));
+	}
+
+	SECTION("An uninitialized_move sends a notification to the handler")
+	{
+		Allocator::Value value;
+		std::uninitialized_move_n(&value, 1, allocation);
+
+		REQUIRE(
+		    Allocator::handler()->events().back()
+		    == create_move_construct_event(allocation, &value));
+	}
+
+	Alloc_Traits::destroy(monitor, allocation);
+	Alloc_Traits::deallocate(monitor, allocation, count);
+}
+
+TEST_CASE(
+    "Monitor correctly constructs objects with passed parameters",
+    "[monitor]")
+{
+	using Allocator =
+	    dsa::Memory_Monitor<No_Default_Constructor_Value, Event_Handler>;
+	using Alloc_Traits = dsa::Allocator_Traits<Allocator>;
+
+	Memory_Monitor_Scope<Allocator::Underlying_Value, Event_Handler> scope;
+
+	Allocator monitor;
+
+	size_t count      = 1;
+	auto  *allocation = Alloc_Traits::allocate(monitor, count);
+	Alloc_Traits::construct(
+	    monitor,
+	    allocation,
+	    No_Default_Constructor_Value_Construct_Tag());
+
+	REQUIRE(
+	    Allocator::handler()->events().back()
+	    == create_construct_event(allocation));
+
+	Alloc_Traits::destroy(monitor, allocation);
+	Alloc_Traits::deallocate(monitor, allocation, count);
+}
+
+TEST_CASE(
+    "Element_Monitor can be constructed from the underlying value",
+    "[monitor]")
+{
+	using Allocator    = dsa::Memory_Monitor<Empty_Value, Event_Handler>;
+	using Alloc_Traits = dsa::Allocator_Traits<Allocator>;
+
+	Memory_Monitor_Scope<Allocator::Underlying_Value, Event_Handler> scope;
+
+	Allocator monitor;
+
+	size_t count      = 1;
+	auto  *allocation = Alloc_Traits::allocate(monitor, count);
+	Alloc_Traits::construct(monitor, allocation, Allocator::Underlying_Value());
+
+	REQUIRE(
+	    Allocator::handler()->events().back()
+	    == create_construct_event(allocation));
+
+	Alloc_Traits::destroy(monitor, allocation);
+	Alloc_Traits::deallocate(monitor, allocation, count);
+}
+
+TEST_CASE("Monitor notifies handler about object assignment", "[monitor]")
+{
+	using Allocator    = dsa::Memory_Monitor<Empty_Value, Event_Handler>;
+	using Alloc_Traits = dsa::Allocator_Traits<Allocator>;
+
+	Memory_Monitor_Scope<Allocator::Underlying_Value, Event_Handler> scope;
+
+	Allocator        monitor;
+	Allocator::Value value;
+	Empty_Value      underlying_value;
+
+	size_t count      = 1;
+	auto  *allocation = Alloc_Traits::allocate(monitor, count);
+	std::uninitialized_default_construct_n(allocation, 1);
+
+	SECTION("Monitor detects copy assignment")
+	{
+		*allocation = value;
+
+		REQUIRE(
+		    Allocator::handler()->events().back()
+		    == create_copy_assign_event(allocation, &value));
+	}
+
+	SECTION("Monitor detects copy assignment from the underlying value")
+	{
+		*allocation = underlying_value;
+
+		REQUIRE(
+		    Allocator::handler()->events().back()
+		    == create_copy_assign_event<Allocator::Value>(
+			allocation,
+			nullptr));
+	}
+
+	SECTION("Monitor detects move assignment")
+	{
+		*allocation = std::move(value);
+
+		REQUIRE(
+		    Allocator::handler()->events().back()
+		    == create_move_assign_event(allocation, &value));
+	}
+
+	SECTION("Monitor detects move assignment from the underlying value")
+	{
+		*allocation = std::move(underlying_value);
+		REQUIRE(
+		    Allocator::handler()->events().back()
+		    == create_move_assign_event<Allocator::Value>(
+			allocation,
+			nullptr));
+	}
+
+	Alloc_Traits::destroy(monitor, allocation);
+	Alloc_Traits::deallocate(monitor, allocation, count);
+}
+
+TEST_CASE("Monitor notifies handler about object destruction", "[monitor]")
+{
+	using Allocator    = dsa::Memory_Monitor<Empty_Value, Event_Handler>;
+	using Alloc_Traits = dsa::Allocator_Traits<Allocator>;
+
+	Memory_Monitor_Scope<Allocator::Underlying_Value, Event_Handler> scope;
+
+	Allocator monitor;
+
+	size_t count      = 1;
+	auto  *allocation = Alloc_Traits::allocate(monitor, count);
+	Alloc_Traits::construct(monitor, allocation);
+
+	SECTION("Monitor detects destruction through allocation traits")
+	{
+		Alloc_Traits::destroy(monitor, allocation);
+		REQUIRE(
+		    Allocator::handler()->events().back()
+		    == create_destroy_event(allocation));
+	}
+
+	SECTION("Monitor detects destruction through destroy call")
+	{
+		std::destroy_n(allocation, 1);
+		REQUIRE(
+		    Allocator::handler()->events().back()
+		    == create_destroy_event(allocation));
+	}
+
+	Alloc_Traits::deallocate(monitor, allocation, count);
+}
+
+} // namespace test

--- a/test/dsa/dsa_static/no_default_constructor_value.hpp
+++ b/test/dsa/dsa_static/no_default_constructor_value.hpp
@@ -1,0 +1,37 @@
+#ifndef TEST_DSA_STATIC_NO_DEFAULT_CONSTRUCTOR_VALUE_HPP
+#define TEST_DSA_STATIC_NO_DEFAULT_CONSTRUCTOR_VALUE_HPP
+
+namespace test
+{
+
+struct No_Default_Constructor_Value_Construct_Tag
+{
+};
+
+/// This class can only be constructed from the accompanying tag. This allows us
+/// to test that the object was constructed using the provided arguments and not
+/// using a default constructor.
+class No_Default_Constructor_Value
+{
+ public:
+	constexpr explicit No_Default_Constructor_Value() = delete;
+	constexpr explicit No_Default_Constructor_Value(
+	    No_Default_Constructor_Value_Construct_Tag /* tag */)
+	{
+	}
+
+	constexpr ~No_Default_Constructor_Value() = default;
+
+	constexpr No_Default_Constructor_Value(
+	    No_Default_Constructor_Value const &) = delete;
+	constexpr No_Default_Constructor_Value &operator=(
+	    No_Default_Constructor_Value const &) = delete;
+
+	constexpr No_Default_Constructor_Value(No_Default_Constructor_Value &&) = delete;
+	constexpr No_Default_Constructor_Value &operator=(
+	    No_Default_Constructor_Value &&) = delete;
+};
+
+} // namespace test
+
+#endif

--- a/test/dsa/dsa_static/utilities/memory_monitor_scope.hpp
+++ b/test/dsa/dsa_static/utilities/memory_monitor_scope.hpp
@@ -1,0 +1,49 @@
+#ifndef TEST_DSA_STATIC_MEMORY_MONITOR_SCOPE_HPP
+#define TEST_DSA_STATIC_MEMORY_MONITOR_SCOPE_HPP
+
+#include <dsa/memory_monitor.hpp>
+
+#include <iostream>
+
+namespace test
+{
+
+/// The Memory_Monitor class uses a global variable to handle the callbacks.
+/// This class can be used to manage the lifetime of the global instance. This
+/// is useful for tests since we want each test to have a separate instance.
+template<typename Type, dsa::Memory_Monitor_Event_Handler<Type> Event_Handler>
+class Memory_Monitor_Scope
+{
+ public:
+	Memory_Monitor_Scope()
+	{
+		if (Allocator::handler() != nullptr)
+		{
+			std::cerr << "The handler's lifetime should only be "
+				     "controlled "
+				     "by this object";
+			std::terminate();
+		}
+
+		Allocator::handler() = std::make_unique<Event_Handler>();
+	}
+
+	~Memory_Monitor_Scope()
+	{
+		if (Allocator::handler() == nullptr)
+		{
+			std::cerr << "The handler's lifetime should only be "
+				     "controlled "
+				     "by this object";
+			std::terminate();
+		}
+
+		Allocator::handler() = nullptr;
+	}
+
+	using Allocator = dsa::Memory_Monitor<Type, Event_Handler>;
+};
+
+} // namespace test
+
+#endif


### PR DESCRIPTION
This class allows code to peek into how containers are managing memory. We need this functionality from both the visualisation side and the test side of the code. The former needs to visualise the memory of each container while the former tests that the allocation and object life time operations are not miused.