### PR TITLE
[test] allocation_verifier: Allow reassignment to moved memory

### DIFF
--- a/test/dsa/dsa_static/allocation_verifier_tests.cpp
+++ b/test/dsa/dsa_static/allocation_verifier_tests.cpp
@@ -430,6 +430,24 @@ TEST_CASE("Construct can be called on moved values", "[allocation_verifier]")
 	REQUIRE_NOTHROW(Allocation_Verifier::instance()->cleanup());
 }
 
+TEST_CASE("Moved memory can be reassigned", "[allocation_verifier]")
+{
+	Handler_Scope scope;
+	Allocator     verifier;
+
+	size_t count  = 1;
+	auto  *memory = Alloc_Traits::allocate(verifier, count);
+
+	Alloc_Traits::construct(verifier, memory);
+	Allocator::Value value(std::move(*memory));
+	*memory = std::move(value);
+
+	std::destroy_n(memory, count);
+	Alloc_Traits::deallocate(verifier, memory, count);
+
+	REQUIRE_NOTHROW(Allocation_Verifier::instance()->cleanup());
+}
+
 TEST_CASE(
     "Calling destroy on unconstructed memory raises an error",
     "[allocation_verifier]")

--- a/test/dsa/dsa_static/utilities/allocation_verifier.hpp
+++ b/test/dsa/dsa_static/utilities/allocation_verifier.hpp
@@ -111,7 +111,7 @@ class Allocation_Element
 		case dsa::Object_Event_Type::Underlying_Copy_Assign:
 		case dsa::Object_Event_Type::Move_Assign:
 		case dsa::Object_Event_Type::Underlying_Move_Assign:
-			if (m_state != State::Initialised)
+			if (m_state != State::Initialised && m_state != State::Moved)
 			{
 				return assign_uninitialized_memory;
 			}


### PR DESCRIPTION
Moving leaves the state of the memory in a destructible state. This means that we can perform an assignment on it after a move.