### PR TITLE
[actions] We currently do not work with conan2 - install 1.59.0

### DIFF
--- a/.github/workflows/build_cmake.yml
+++ b/.github/workflows/build_cmake.yml
@@ -49,7 +49,7 @@ jobs:
       shell: bash
       run: |
         python3 -m pip install --upgrade pip setuptools
-        python3 -m pip install --upgrade conan
+        python3 -m pip install --upgrade conan==1.59.0
         conan config init
         conan config set general.revisions_enabled=1
         conan profile update conf.tools.system.package_manager:mode=install default

--- a/dependencies/CMakeLists.txt
+++ b/dependencies/CMakeLists.txt
@@ -1,4 +1,5 @@
 # Download automatically, you can also just copy the conan.cmake file
+# TODO: Upgrade to use conan2
 if(NOT EXISTS "${CMAKE_CURRENT_BINARY_DIR}/conan.cmake")
 	message(STATUS "Downloading conan.cmake from https://github.com/conan-io/cmake-conan")
 	file(


### PR DESCRIPTION
We should upgrade sometime in the future, until then use the old working version.