### PR TITLE
[dsa] Send element value to memory_representation when it is changed

### DIFF
--- a/dsa/include/dsa/binary_tree.hpp
+++ b/dsa/include/dsa/binary_tree.hpp
@@ -142,6 +142,19 @@ class Binary_Tree_Node
 	    , m_satellite(std::forward<Arguments>(arguments)...)
 	{
 	}
+
+	friend auto operator<<(std::ostream &stream, Binary_Tree_Node const &node)
+	    -> std::ostream &
+	{
+		// clang-format off
+		return stream << '{'
+				<< node.m_left
+				<< ',' << node.m_parent
+				<< ',' << node.m_right
+				<< ',' << node.m_satellite
+			<< '}';
+		// clang-format on
+	}
 };
 
 } // namespace detail

--- a/dsa/include/dsa/list.hpp
+++ b/dsa/include/dsa/list.hpp
@@ -93,6 +93,17 @@ class List_Node
 
 	Satellite_Value m_satellite;
 	Pointer         m_next = nullptr;
+
+	friend auto operator<<(std::ostream &stream, List_Node const &node)
+	    -> std::ostream &
+	{
+		// clang-format off
+		return stream << '{'
+				<< node.m_next
+				<< ',' << node.m_satellite
+			<< '}';
+		// clang-format on
+	}
 };
 
 } // namespace detail

--- a/dsa/include/dsa/memory_monitor.hpp
+++ b/dsa/include/dsa/memory_monitor.hpp
@@ -5,6 +5,7 @@
 #include <dsa/default_allocator.hpp>
 #include <dsa/type_traits.hpp>
 
+#include <sstream>
 #include <cassert>
 #include <cstddef>
 #include <memory>
@@ -249,6 +250,10 @@ class Object_Event
 			    && "We expect the source to be provided for these events");
 			break;
 		}
+
+		std::stringstream stream;
+		stream << *m_destination;
+		m_destination_value = stream.str();
 	}
 
 	auto operator==(Object_Event const &event) const -> bool = default;
@@ -294,6 +299,11 @@ class Object_Event
 	auto source() -> T const *
 	{
 		return m_source;
+	}
+
+	[[nodiscard]] auto destination_value() const -> std::string const &
+	{
+		return m_destination_value;
 	}
 
 	[[nodiscard]] auto constructing() const -> bool
@@ -357,6 +367,7 @@ class Object_Event
 	Object_Event_Type m_type;
 	T		 *m_destination;
 	T const          *m_source;
+	std::string       m_destination_value;
 };
 
 template<typename Handler, typename Type>
@@ -460,6 +471,12 @@ class Element_Monitor
 		    Object_Event_Type::Underlying_Move_Assign,
 		    &Base_Wrapper::base()));
 		return *this;
+	}
+
+	friend auto operator<<(std::ostream &stream, Element_Monitor const &monitor)
+	    -> std::ostream &
+	{
+		return stream << monitor.base();
 	}
 
  private:
@@ -736,6 +753,12 @@ class Element_Monitor_Pointer : private detail::Pre_Construct
 	auto base() -> Base_Pointer &
 	{
 		return m_base_pointer;
+	}
+
+	friend auto operator<<(std::ostream &stream, Element_Monitor_Pointer const &pointer)
+	    -> std::ostream &
+	{
+		return stream << pointer.get();
 	}
 
  private:

--- a/test/dsa/allocation_verifier_tests.cpp
+++ b/test/dsa/allocation_verifier_tests.cpp
@@ -613,6 +613,17 @@ struct Multiple_Field_Struct
 	typename Single_Field_Allocator::Value field_b;
 
 	Multiple_Field_Struct() = default;
+
+	friend auto operator<<(std::ostream &stream, Multiple_Field_Struct const &data)
+	    -> std::ostream &
+	{
+		// clang-format off
+		return stream << '{'
+			          << data.field_a
+			          << ',' << data.field_b
+			      << '}';
+		// clang-format on
+	}
 };
 
 using Multiple_Field_Allocator =

--- a/test/dsa/empty_value.hpp
+++ b/test/dsa/empty_value.hpp
@@ -1,8 +1,15 @@
 #ifndef TEST_DSA_STATIC_EMPTY_VALUE_HPP
 #define TEST_DSA_STATIC_EMPTY_VALUE_HPP
 
+#include <ostream>
+
 struct Empty_Value
 {
+	friend auto operator<<(std::ostream &stream, Empty_Value const & /*value*/)
+	    -> std::ostream &
+	{
+		return stream << "{}";
+	}
 };
 
 #endif

--- a/test/dsa/no_default_constructor_value.hpp
+++ b/test/dsa/no_default_constructor_value.hpp
@@ -1,6 +1,8 @@
 #ifndef TEST_DSA_STATIC_NO_DEFAULT_CONSTRUCTOR_VALUE_HPP
 #define TEST_DSA_STATIC_NO_DEFAULT_CONSTRUCTOR_VALUE_HPP
 
+#include <ostream>
+
 namespace test
 {
 
@@ -30,6 +32,13 @@ class No_Default_Constructor_Value
 	constexpr No_Default_Constructor_Value(No_Default_Constructor_Value &&) = delete;
 	constexpr No_Default_Constructor_Value &operator=(
 	    No_Default_Constructor_Value &&) = delete;
+
+	friend auto operator<<(
+	    std::ostream &stream,
+	    No_Default_Constructor_Value const & /*value*/) -> std::ostream &
+	{
+		return stream << "{}";
+	}
 };
 
 } // namespace test

--- a/todo.txt
+++ b/todo.txt
@@ -43,6 +43,7 @@ Development:
 	Issues:
 		DSA:
 			Binary_Tree does not account for duplicates
+			Object_Event_Type::Underlying_(Copy/Move)_Assign can be merged together into Underlying_Value_Assign
 
 		Visual:
 			Container queries run per frame so non constant operations dirty the log with duplicated events
@@ -50,6 +51,7 @@ Development:
 			Simplify memory representation classes
 			Viewport should not have rendering code + rename the class
 			Use the size to determine if a pointer is pointing to the buffer or to a particular value
+			Pop should not be clickable when there are no items in the heap
 
 
 	Research:
@@ -70,4 +72,4 @@ Testing:
 	Use Memory_Monitor_Event_Handler_Fixture in all the tests that need a handler
 
 	DSA:
-		Create a struct for testing destructor. shared_ptr does not work because calling a single destructor multiple times (undefined behaviour yes but double frees do happen) It is better to check that each element was individually destroyed with a custom allocator.
+		Memory_Representation is currently untested. It was moved from inside Allocation_Verifier - which is tested but during the extraction the tests were not written for it. The tests for Allocation_Verifier can now be set up by creating a memory representation instance and passing it directly to the verifier, instead of creating it through the interface (decide if this option is better or not)


### PR DESCRIPTION
Since we can process the events separately from the time at which they are dispatched we do not know if pointer accesses are safe. Since we need to know the value for certain operations we send a copy of it when the event is dispatched, this makes sure we do not need to access it later.